### PR TITLE
Finzlizing (for now...) text wrapping for display

### DIFF
--- a/src/components/views/DispatchView.vue
+++ b/src/components/views/DispatchView.vue
@@ -20,8 +20,8 @@
               :key="call.callID"
               :class="getRowClass(call.status)"
             >
-              <td>{{ call.location }}</td>
-              <td>{{ call.complaint }}</td>
+              <td>{{ truncateText(call.location) }}</td>
+              <td>{{ truncateText(call.complaint) }}</td>
               <td>{{ call.open_time }}</td>
               <td>
                 <select
@@ -41,7 +41,9 @@
               </td>
               <td>{{ call.status }}</td>
               <td>
-                <button @click="openModal(call.callID)" class="detailsButton">Show Details</button>
+                <button @click="openModal(call.callID)" class="detailsButton">
+                  Show Details
+                </button>
               </td>
             </tr>
 
@@ -50,8 +52,8 @@
               :key="call.callID"
               :class="getRowClass(call.status)"
             >
-              <td>{{ call.location }}</td>
-              <td>{{ call.complaint }}</td>
+              <td>{{ truncateText(call.location) }}</td>
+              <td>{{ truncateText(call.complaint) }}</td>
               <td>{{ call.open_time }}</td>
               <td>
                 <select
@@ -71,7 +73,9 @@
               </td>
               <td>{{ call.status }}</td>
               <td>
-                <button @click="openModal(call.callID)" class="detailsButton">Show Details</button>
+                <button @click="openModal(call.callID)" class="detailsButton">
+                  Show Details
+                </button>
               </td>
             </tr>
 
@@ -80,8 +84,8 @@
               :key="call.callID"
               :class="getRowClass(call.status)"
             >
-              <td>{{ call.location }}</td>
-              <td>{{ call.complaint }}</td>
+              <td>{{ truncateText(call.location) }}</td>
+              <td>{{ truncateText(call.complaint) }}</td>
               <td>{{ call.open_time }}</td>
               <td>
                 <select
@@ -101,7 +105,9 @@
               </td>
               <td>{{ call.status }}</td>
               <td>
-                <button @click="openModal(call.callID)" class="detailsButton">Show Details</button>
+                <button @click="openModal(call.callID)" class="detailsButton">
+                  Show Details
+                </button>
               </td>
             </tr>
           </table>
@@ -189,16 +195,17 @@
       :isOpen="isModalOpened"
       :currentCall="currentCall"
       @modal-close="closeModal"
-      name="Detail Modal">
+      name="Detail Modal"
+    >
     </modal-component>
 
     <unit-modal
       :isOpen="isUnitModalOpened"
       @modal-close="closeUnitModal"
-      name="Unit Modal">
+      name="Unit Modal"
+    >
     </unit-modal>
   </div>
-  
 </template>
 
 <style scoped>
@@ -321,6 +328,11 @@ tr {
   margin: 20px;
   text-align: left;
 
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 300px; /* Adjust as needed */
+
   max-width: 20ch;
   word-wrap: break-word;
 }
@@ -422,7 +434,7 @@ const updateAssignedUnit = (callID, unitID) => {
 
 // Function to close the call
 const closeCall = (callID, status) => {
-  console.log(callID)
+  console.log(callID);
   // Check if the call is already closed or has a "Closed" status
   if (status === "Closed") {
     console.log("Call is already closed");
@@ -549,6 +561,14 @@ const displayPhoneFormat = (number) => {
   return phoneNumber;
 };
 
+// Truncate Text Function
+const truncateText = (text) => {
+  if (text.length > 100) {
+    return text.substring(0, 100) + "...";
+  }
+  return text;
+};
+
 // Call Sorting
 const unassignedCalls = computed(() => {
   return calls.value
@@ -613,8 +633,8 @@ const providedFunctions = {
   displayPhoneFormat,
   closeCall,
   getUnits,
-  getCalls
+  getCalls,
 };
 
-provide('providedFunctions', providedFunctions);
+provide("providedFunctions", providedFunctions);
 </script>

--- a/src/components/views/ModalComponent.vue
+++ b/src/components/views/ModalComponent.vue
@@ -22,12 +22,12 @@ const call = computed(() => props.currentCall[0]);
     <div class="modal-container" ref="target">
 
       <div class="modal-header">
-        <div class="btnRight">
-          <button @click="emit('modal-close')" class="close-btn">X</button>
-        </div>
-
         <div class="header">
           <h2 class="content">Call Details for Run Number: {{ call.callID }}</h2>
+        </div>
+
+        <div class="btnRight">
+          <button @click="emit('modal-close')" class="close-btn">X</button>
         </div>
       </div>
 
@@ -77,36 +77,32 @@ const call = computed(() => props.currentCall[0]);
   max-width: calc(100% - 80px);
   max-height: calc(100% - 80px);
   overflow: auto;
-  max-height: calc(100vh - 125px);
 }
 
 .modal-header {
   display: flex;
-  justify-content: flex-start;
-  position: relative;
+  justify-content: space-between;
+  align-items: center;
   width: 100%;
-  margin: 20px;
+  margin-bottom: 20px;
 }
 
 .header {
-  flex: 0 1 auto;
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
+  flex: 1;
+  text-align: center;
 }
 
 .btnRight {
-  flex: 0 1 auto;
+  flex: 0;
   margin-left: auto;
-  margin-right: 20px;
 }
 
 .close-btn {
   border: 2px solid black;
   background-color: white;
   color: black;
-  padding: 14px 28px;
-  font-size: 20px;
+  padding: 10px 20px;
+  font-size: 16px;
   cursor: pointer;
   border-color: #f44336;
   color: #f44336;
@@ -117,10 +113,17 @@ const call = computed(() => props.currentCall[0]);
 }
 
 .modal-body {
-  display: grid;
-  justify-content: center;
-  justify-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
   font-size: 16px;
+  text-align: left; /* Ensuring text within modal body is left-aligned */
+}
+
+.content {
+  word-wrap: break-word;
+  margin: 5px 0;
+  max-width: 100%; /* Ensuring content doesn't exceed the modal width */
 }
 
 .heading {
@@ -128,18 +131,17 @@ const call = computed(() => props.currentCall[0]);
 }
 
 .modal-footer {
-  margin: 20px;
-  display: grid;
+  display: flex;
   justify-content: center;
-  justify-items: center;
+  margin-top: 20px;
 }
 
 .closeCallBtn {
   border: 2px solid black;
   background-color: white;
   color: black;
-  padding: 14px 28px;
-  font-size: 20px;
+  padding: 10px 20px;
+  font-size: 16px;
   cursor: pointer;
   border-color: #f44336;
   color: #f44336;
@@ -157,6 +159,21 @@ const call = computed(() => props.currentCall[0]);
   color: #666;
   background-color: white;
   cursor: default;
+}
+
+@media (max-width: 768px) {
+  .modal-container {
+    width: 90%;
+  }
+
+  .modal-header {
+    flex-direction: row-reverse; /* Ensuring close button stays on the right */
+  }
+
+  .header {
+    text-align: center;
+    margin-top: 10px;
+  }
 }
 
 </style>


### PR DESCRIPTION
Hopefully this helps. Data in the "Location" and "Complaint" columns is now truncated with "..." after it exceeds its maximum width. 

![image](https://github.com/aidan-lemay/DispatchDirect/assets/34166033/e79a7826-0d71-4ebe-be44-a8dfb6865220)

Data in the modal is adjusted to fit inside the card without the need for horizontal scrolling.

![image](https://github.com/aidan-lemay/DispatchDirect/assets/34166033/b4729b66-a6eb-4c97-996d-ba07ce20e446)

Ideally...
Closes #14 